### PR TITLE
Feat & Fix

### DIFF
--- a/Effi-BE-fin/src/main/java/com/example/effi/controller/ScheduleController.java
+++ b/Effi-BE-fin/src/main/java/com/example/effi/controller/ScheduleController.java
@@ -208,4 +208,11 @@ public class ScheduleController {
         }
     }
 
+    //그룹 탈퇴시 그룹 스케줄 삭제
+    @PutMapping("/delete/groupSchedule/{groupId}")
+    public ResponseEntity<?> deleteGroupSchedule(@PathVariable("groupId") Long groupId){
+        List<ScheduleResponseDTO> scheduleResponseDTOS = scheduleService.deleteGroupSchedule(groupId);
+        return ResponseEntity.ok(scheduleResponseDTOS);
+    }
+
 }

--- a/Effi-BE-fin/src/main/java/com/example/effi/service/ScheduleService.java
+++ b/Effi-BE-fin/src/main/java/com/example/effi/service/ScheduleService.java
@@ -33,6 +33,7 @@ public class ScheduleService {
     private final ParticipantRepository participantRepository;
     private final ParticipantService participantService;
     private final EmployeeService employeeService;
+    private final CategoryService categoryService;
 
     //scheduleId로 schedule 조회
     public ScheduleResponseDTO getSchedule(Long scheduleId) {
@@ -228,6 +229,21 @@ public class ScheduleService {
         }
         sch.delete();
         scheduleRepository.save(sch);
+    }
+
+    // group나갔을때 그 그룹에 해당하는 스케줄 삭제
+    public List<ScheduleResponseDTO> deleteGroupSchedule(Long groupId){
+        CategoryResponseDTO byGroupId = categoryService.findByGroupId(groupId);
+        Long categoryNo = byGroupId.getCategoryNo();
+        List<Schedule> allByCategortyCategoryNo = scheduleRepository.findAllByCategory_CategoryNo(categoryNo);
+
+        List<ScheduleResponseDTO> res = new ArrayList<>();
+        for (Schedule sch : allByCategortyCategoryNo) {
+            sch.delete();
+            scheduleRepository.save(sch);
+            res.add(new ScheduleResponseDTO(sch));
+        }
+        return res;
     }
 
 }

--- a/Effi-BE-fin/src/main/java/com/example/effi/service/ScheduleService.java
+++ b/Effi-BE-fin/src/main/java/com/example/effi/service/ScheduleService.java
@@ -34,6 +34,7 @@ public class ScheduleService {
     private final ParticipantService participantService;
     private final EmployeeService employeeService;
     private final CategoryService categoryService;
+    private final RoutineService routineService;
 
     //scheduleId로 schedule 조회
     public ScheduleResponseDTO getSchedule(Long scheduleId) {
@@ -210,6 +211,7 @@ public class ScheduleService {
         }
         Routine routine = routineRepository.findById(routineId).orElse(null);
         if (routine == null || routine.getDeleteYn() == true) {
+            // 루틴 삭제시 하나만 스케줄 하나에 해당하는 루틴만 삭제
             sch.update(sch.getTitle(), sch.getContext(), sch.getStartTime(),
                     sch.getEndTime(), sch.getStatus(), sch.getNotificationYn(),
                     sch.getCategory(), null);
@@ -218,7 +220,9 @@ public class ScheduleService {
         sch.update(sch.getTitle(), sch.getContext(), sch.getStartTime(),
                 sch.getEndTime(), sch.getStatus(), sch.getNotificationYn(),
                 sch.getCategory(), routine);
-        return new ScheduleResponseDTO(scheduleRepository.save(sch));
+        ScheduleResponseDTO scheduleResponseDTO = new ScheduleResponseDTO(scheduleRepository.save(sch));
+        addRoutineSchedule(scheduleResponseDTO);
+        return scheduleResponseDTO;
     }
 
     // delete schedule


### PR DESCRIPTION
- add function : delete schedule when withdrawGroup
```
// ScheduleController.java
 //그룹 탈퇴시 그룹 스케줄 삭제
    @PutMapping("/delete/groupSchedule/{groupId}")
    public ResponseEntity<?> deleteGroupSchedule(@PathVariable("groupId") Long groupId){
        List<ScheduleResponseDTO> scheduleResponseDTOS = scheduleService.deleteGroupSchedule(groupId);
        return ResponseEntity.ok(scheduleResponseDTOS);
    }
    
// ScheduleService.java
// group나갔을때 그 그룹에 해당하는 스케줄 삭제
    public List<ScheduleResponseDTO> deleteGroupSchedule(Long groupId){
        CategoryResponseDTO byGroupId = categoryService.findByGroupId(groupId);
        Long categoryNo = byGroupId.getCategoryNo();
        List<Schedule> allByCategortyCategoryNo = scheduleRepository.findAllByCategory_CategoryNo(categoryNo);

        List<ScheduleResponseDTO> res = new ArrayList<>();
        for (Schedule sch : allByCategortyCategoryNo) {
            sch.delete();
            scheduleRepository.save(sch);
            res.add(new ScheduleResponseDTO(sch));
        }
        return res;
    }
```
위 함수 중 두개 골라서 쓰면 됨 (controller는 프론트랑 연결해서 쓰고 service는 그룹관련 함수에 추가해서 사용하길)

-----
- Routine delete & update 기능 수정
delete의 경우 schedule 수정 화면에서 이루어진다고 가정 -> 해당 스케줄의 루틴만 삭제
```
ScheduleController -> updateSchedule
ScheduleService -> updateRoutine
```
update의 경우 동일하게 schedule 수정 화면에서 이루어진다고 가정 -> 해당 스케줄의 루틴 수정 + 추가 스케줄 생성
```
ScheduleController -> updateSchedule
ScheduleService -> updateRoutine -> addRoutineSchedule
```